### PR TITLE
Fix duplicate interface definition

### DIFF
--- a/src/app/personality/profile/models/profile-response.model.ts
+++ b/src/app/personality/profile/models/profile-response.model.ts
@@ -162,9 +162,3 @@ export interface SourceLocation {
 export interface Posts {
   posts: any[];
 }
-
-export interface MbtiLetterStat {
-  type: string;
-  percentage: string;
-  PercentageFloat: number;
-}


### PR DESCRIPTION
## Summary
- remove the duplicate `MbtiLetterStat` interface from the profile model

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684aff3284a0832e94c5d17fafb2aa9a