### PR TITLE
Add dark theme styles

### DIFF
--- a/src/app/app.component.css
+++ b/src/app/app.component.css
@@ -1,0 +1,9 @@
+nav a {
+  color: #64b5f6;
+  text-decoration: none;
+  margin-right: 1rem;
+}
+
+nav a:hover {
+  text-decoration: underline;
+}

--- a/src/app/npc-simulation/npc-simulation.component.css
+++ b/src/app/npc-simulation/npc-simulation.component.css
@@ -1,3 +1,3 @@
 .simulation-canvas {
-  border: 1px solid red;
+  border: 1px solid #444;
 }

--- a/src/app/personality/personality.component.css
+++ b/src/app/personality/personality.component.css
@@ -5,17 +5,20 @@
   gap: 1rem;
 }
 .personality-card {
-  border: 1px solid #ccc;
+  border: 1px solid #444;
   border-radius: 4px;
   padding: 1rem;
   cursor: pointer;
   width: 200px;
+  background-color: #1e1e1e;
+  color: #fff;
   transition: box-shadow 0.3s;
 }
 .personality-card:hover {
-  box-shadow: 0 2px 8px rgba(0,0,0,0.2);
+  box-shadow: 0 2px 8px rgba(255,255,255,0.1);
 }
 .loading-more {
   text-align: center;
   margin: 1rem 0;
+  color: #ccc;
 }

--- a/src/app/profile-selector/profile-selector.component.css
+++ b/src/app/profile-selector/profile-selector.component.css
@@ -10,4 +10,5 @@ div {
 
 label {
     margin-bottom: 0.5rem;
+    color: #f0f0f0;
 }

--- a/src/styles.css
+++ b/src/styles.css
@@ -1,1 +1,30 @@
-/* You can add global styles to this file, and also import other style files */
+/* Base dark theme styles */
+body {
+  margin: 0;
+  background-color: #121212;
+  color: #f0f0f0;
+  font-family: Arial, Helvetica, sans-serif;
+}
+
+a {
+  color: #64b5f6;
+}
+
+nav {
+  background-color: #1f1f1f;
+  padding: 1rem;
+}
+
+button,
+select,
+input {
+  background-color: #2c2c2c;
+  color: #f0f0f0;
+  border: 1px solid #444;
+  border-radius: 4px;
+  padding: 0.25rem 0.5rem;
+}
+
+button:hover {
+  background-color: #3a3a3a;
+}


### PR DESCRIPTION
## Summary
- update global styles with dark palette
- style navigation links
- update NPC simulation and personality styles for dark background
- color profile selector labels

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b0447d92c832e89c0954f543071b9