### PR TITLE
Add zoom controls to NPC simulation

### DIFF
--- a/src/app/npc-simulation/npc-simulation.component.css
+++ b/src/app/npc-simulation/npc-simulation.component.css
@@ -1,4 +1,5 @@
 .simulation-wrapper {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -33,4 +34,29 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.25rem;
+}
+
+.zoom-controls {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.zoom-btn {
+  background: transparent;
+  border: none;
+  cursor: pointer;
+  font-size: 1.2rem;
+  color: #000;
+  width: 2rem;
+  height: 2rem;
+  line-height: 2rem;
+  text-align: center;
+}
+
+.zoom-btn:hover {
+  background: rgba(0, 0, 0, 0.1);
 }

--- a/src/app/npc-simulation/npc-simulation.component.html
+++ b/src/app/npc-simulation/npc-simulation.component.html
@@ -1,5 +1,9 @@
 <div class="simulation-wrapper">
   <svg #svgContainer class="simulation-canvas"></svg>
+  <div class="zoom-controls">
+    <button class="zoom-btn" (click)="zoomIn()">+</button>
+    <button class="zoom-btn" (click)="zoomOut()">-</button>
+  </div>
   <div class="controls">
     <button (click)="addNpc($event)">Add NPC</button>
     <input type="text" [(ngModel)]="searchTerm" (input)="onSearchTermChange()" (keyup.enter)="search()" placeholder="Search characters" />


### PR DESCRIPTION
## Summary
- support zooming the D3 graph with mouse wheel
- add transparent zoom in/out buttons

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3aaf1a58832ea2f2628a2fd82765