### PR TITLE
Add dark-themed zoom buttons

### DIFF
--- a/src/app/AGENTS.md
+++ b/src/app/AGENTS.md
@@ -5,3 +5,4 @@ This directory holds the root Angular component used across the application.
 - `AppComponent` is a standalone component with a `<router-outlet>` for routing.
 - Keep the `title` property and navigation links intact when modifying the layout.
 - Use Angular routing to navigate to features such as the NPC simulation or profile views.
+- The application uses a **dark theme**; ensure new components and styles maintain this look.

--- a/src/app/npc-simulation/npc-simulation.component.css
+++ b/src/app/npc-simulation/npc-simulation.component.css
@@ -1,4 +1,5 @@
 .simulation-wrapper {
+  position: relative;
   display: flex;
   flex-direction: column;
   align-items: center;
@@ -33,4 +34,30 @@
   justify-content: space-between;
   align-items: center;
   margin-bottom: 0.25rem;
+}
+
+.zoom-controls {
+  position: absolute;
+  top: 0.5rem;
+  right: 0.5rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+}
+
+.zoom-btn {
+  background: transparent;
+  border: 1px solid #444;
+  border-radius: 4px;
+  cursor: pointer;
+  font-size: 1.2rem;
+  color: #f0f0f0;
+  width: 2rem;
+  height: 2rem;
+  line-height: 2rem;
+  text-align: center;
+}
+
+.zoom-btn:hover {
+  background: rgba(255, 255, 255, 0.1);
 }

--- a/src/app/npc-simulation/npc-simulation.component.html
+++ b/src/app/npc-simulation/npc-simulation.component.html
@@ -1,5 +1,9 @@
 <div class="simulation-wrapper">
   <svg #svgContainer class="simulation-canvas"></svg>
+  <div class="zoom-controls">
+    <button class="zoom-btn" (click)="zoomIn()">+</button>
+    <button class="zoom-btn" (click)="zoomOut()">-</button>
+  </div>
   <div class="controls">
     <button (click)="addNpc($event)">Add NPC</button>
     <input type="text" [(ngModel)]="searchTerm" (input)="onSearchTermChange()" (keyup.enter)="search()" placeholder="Search characters" />


### PR DESCRIPTION
## Summary
- style zoom buttons so they fit the dark theme
- remind contributors about the dark theme in AGENTS.md

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b3aaf1a58832ea2f2628a2fd82765