### PR TITLE
Extract NPC sidebar

### DIFF
--- a/src/app/npc-simulation/npc-simulation.component.css
+++ b/src/app/npc-simulation/npc-simulation.component.css
@@ -57,46 +57,6 @@
   height: 80vh;
 }
 
-.profile-sidebar {
-  width: 300px;
-  min-width: 200px;
-  max-width: 500px;
-  height: 80vh;
-  overflow-y: auto;
-  border-left: 1px solid #444;
-  padding: 1rem;
-  background: #222;
-  color: #f0f0f0;
-}
-
-.profile-sidebar img {
-  width: 100%;
-  border-radius: 4px;
-  margin-bottom: 0.5rem;
-}
-
-.system-votes {
-  list-style: none;
-  padding: 0;
-  margin: 0 0 0.5rem 0;
-}
-
-.system-votes li {
-  margin-bottom: 0.25rem;
-}
-
-.profile-sidebar button {
-  margin-bottom: 0.5rem;
-  padding: 0.25rem 0.5rem;
-  background: #333;
-  border: 1px solid #555;
-  color: #f0f0f0;
-  cursor: pointer;
-}
-
-.profile-sidebar button:hover {
-  background: #444;
-}
 
 .zoom-btn {
   background: transparent;

--- a/src/app/npc-simulation/npc-simulation.component.html
+++ b/src/app/npc-simulation/npc-simulation.component.html
@@ -29,5 +29,6 @@
     *ngIf="hoveredProfile as profile"
     [profile]="profile"
     #sidebar
+    [style.width.px]="sidebarWidth"
   ></app-profile-sidebar>
 </div>

--- a/src/app/npc-simulation/npc-simulation.component.html
+++ b/src/app/npc-simulation/npc-simulation.component.html
@@ -25,22 +25,9 @@
     (mousedown)="initResize($event)"
   ></div>
 
-  <div class="profile-sidebar" *ngIf="hoveredProfile as profile" #sidebar>
-    <h3>{{ profile.profile_name || profile.mbti_profile }}</h3>
-    <img *ngIf="profile.profile_image_url" [src]="profile.profile_image_url" alt="{{ profile.profile_name }}" />
-    <p><strong>MBTI:</strong> {{ profile.mbti_type }}</p>
-    <p><strong>Category:</strong> {{ profile.category }} / {{ profile.subcategory }}</p>
-    <p><strong>Votes:</strong> {{ profile.vote_count }} | <strong>Comments:</strong> {{ profile.comment_count }}</p>
-    <div *ngIf="profile.systems?.length">
-      <h4>Best Votes</h4>
-      <ul class="system-votes">
-        <li *ngFor="let sys of profile.systems">
-          <span [style.color]="sys.hex_color">{{ sys.system_name }}</span>:
-          {{ sys.personality_type }}
-        </li>
-      </ul>
-    </div>
-    <button (click)="openProfilePage(profile.id)">Open Profile</button>
-    <div [innerHTML]="profile.wiki_description_html"></div>
-  </div>
+  <app-profile-sidebar
+    *ngIf="hoveredProfile as profile"
+    [profile]="profile"
+    #sidebar
+  ></app-profile-sidebar>
 </div>

--- a/src/app/npc-simulation/npc-simulation.component.ts
+++ b/src/app/npc-simulation/npc-simulation.component.ts
@@ -8,11 +8,12 @@ import {ProfileService} from '../personality/profile/services/profile.service';
 import {ProfileResponse} from '../personality/profile/models/profile-response.model';
 import {SearchResponseProfile} from '../personality/profile/models/search-response.model';
 import { Subscription } from 'rxjs';
+import { ProfileSidebarComponent } from './profile-sidebar.component';
 
 @Component({
   selector: 'app-npc-simulation',
   standalone: true,
-  imports: [CommonModule, FormsModule],
+  imports: [CommonModule, FormsModule, ProfileSidebarComponent],
   templateUrl: './npc-simulation.component.html',
   styleUrls: ['./npc-simulation.component.css']
 })
@@ -36,7 +37,7 @@ export class NpcSimulationComponent implements AfterViewInit, OnDestroy {
   private searchSub?: Subscription;
 
   hoveredProfile: ProfileResponse | null = null;
-  @ViewChild('sidebar') sidebar?: ElementRef<HTMLDivElement>;
+  @ViewChild('sidebar', { read: ElementRef }) sidebar?: ElementRef<HTMLElement>;
   private isResizing = false;
   private resizeStart = 0;
   private sidebarStartWidth = 0;

--- a/src/app/npc-simulation/npc-simulation.component.ts
+++ b/src/app/npc-simulation/npc-simulation.component.ts
@@ -38,6 +38,7 @@ export class NpcSimulationComponent implements AfterViewInit, OnDestroy {
 
   hoveredProfile: ProfileResponse | null = null;
   @ViewChild('sidebar', { read: ElementRef }) sidebar?: ElementRef<HTMLElement>;
+  sidebarWidth = 300;
   private isResizing = false;
   private resizeStart = 0;
   private sidebarStartWidth = 0;
@@ -188,7 +189,7 @@ export class NpcSimulationComponent implements AfterViewInit, OnDestroy {
     }
     this.isResizing = true;
     this.resizeStart = event.clientX;
-    this.sidebarStartWidth = this.sidebar.nativeElement.offsetWidth;
+    this.sidebarStartWidth = this.sidebarWidth;
     window.addEventListener('mousemove', this.onMouseMove);
     window.addEventListener('mouseup', this.stopResize);
   }
@@ -200,7 +201,7 @@ export class NpcSimulationComponent implements AfterViewInit, OnDestroy {
     const dx = this.resizeStart - event.clientX;
     let newWidth = this.sidebarStartWidth + dx;
     newWidth = Math.min(Math.max(newWidth, 200), 500);
-    this.sidebar.nativeElement.style.width = `${newWidth}px`;
+    this.sidebarWidth = newWidth;
   };
 
   private stopResize = (): void => {

--- a/src/app/npc-simulation/profile-sidebar.component.css
+++ b/src/app/npc-simulation/profile-sidebar.component.css
@@ -1,5 +1,5 @@
-.profile-sidebar {
-  width: 300px;
+:host {
+  display: block;
   min-width: 200px;
   max-width: 500px;
   height: 80vh;
@@ -10,7 +10,7 @@
   color: #f0f0f0;
 }
 
-.profile-sidebar img {
+img {
   width: 100%;
   border-radius: 4px;
   margin-bottom: 0.5rem;
@@ -26,7 +26,7 @@
   margin-bottom: 0.25rem;
 }
 
-.profile-sidebar button {
+button {
   margin-bottom: 0.5rem;
   padding: 0.25rem 0.5rem;
   background: #333;
@@ -35,6 +35,6 @@
   cursor: pointer;
 }
 
-.profile-sidebar button:hover {
+button:hover {
   background: #444;
 }

--- a/src/app/npc-simulation/profile-sidebar.component.css
+++ b/src/app/npc-simulation/profile-sidebar.component.css
@@ -1,0 +1,40 @@
+.profile-sidebar {
+  width: 300px;
+  min-width: 200px;
+  max-width: 500px;
+  height: 80vh;
+  overflow-y: auto;
+  border-left: 1px solid #444;
+  padding: 1rem;
+  background: #222;
+  color: #f0f0f0;
+}
+
+.profile-sidebar img {
+  width: 100%;
+  border-radius: 4px;
+  margin-bottom: 0.5rem;
+}
+
+.system-votes {
+  list-style: none;
+  padding: 0;
+  margin: 0 0 0.5rem 0;
+}
+
+.system-votes li {
+  margin-bottom: 0.25rem;
+}
+
+.profile-sidebar button {
+  margin-bottom: 0.5rem;
+  padding: 0.25rem 0.5rem;
+  background: #333;
+  border: 1px solid #555;
+  color: #f0f0f0;
+  cursor: pointer;
+}
+
+.profile-sidebar button:hover {
+  background: #444;
+}

--- a/src/app/npc-simulation/profile-sidebar.component.html
+++ b/src/app/npc-simulation/profile-sidebar.component.html
@@ -1,5 +1,4 @@
-<div class="profile-sidebar" *ngIf="profile" #sidebar>
-  <h3>{{ profile.profile_name || profile.mbti_profile }}</h3>
+<h3>{{ profile.profile_name || profile.mbti_profile }}</h3>
   <img *ngIf="profile.profile_image_url" [src]="profile.profile_image_url" alt="{{ profile.profile_name }}" />
   <p><strong>MBTI:</strong> {{ profile.mbti_type }}</p>
   <p><strong>Category:</strong> {{ profile.category }} / {{ profile.subcategory }}</p>
@@ -15,4 +14,3 @@
   </div>
   <button (click)="openProfilePage(profile.id)">Open Profile</button>
   <div [innerHTML]="profile.wiki_description_html"></div>
-</div>

--- a/src/app/npc-simulation/profile-sidebar.component.html
+++ b/src/app/npc-simulation/profile-sidebar.component.html
@@ -1,0 +1,18 @@
+<div class="profile-sidebar" *ngIf="profile" #sidebar>
+  <h3>{{ profile.profile_name || profile.mbti_profile }}</h3>
+  <img *ngIf="profile.profile_image_url" [src]="profile.profile_image_url" alt="{{ profile.profile_name }}" />
+  <p><strong>MBTI:</strong> {{ profile.mbti_type }}</p>
+  <p><strong>Category:</strong> {{ profile.category }} / {{ profile.subcategory }}</p>
+  <p><strong>Votes:</strong> {{ profile.vote_count }} | <strong>Comments:</strong> {{ profile.comment_count }}</p>
+  <div *ngIf="profile.systems?.length">
+    <h4>Best Votes</h4>
+    <ul class="system-votes">
+      <li *ngFor="let sys of profile.systems">
+        <span [style.color]="sys.hex_color">{{ sys.system_name }}</span>:
+        {{ sys.personality_type }}
+      </li>
+    </ul>
+  </div>
+  <button (click)="openProfilePage(profile.id)">Open Profile</button>
+  <div [innerHTML]="profile.wiki_description_html"></div>
+</div>

--- a/src/app/npc-simulation/profile-sidebar.component.spec.ts
+++ b/src/app/npc-simulation/profile-sidebar.component.spec.ts
@@ -1,0 +1,24 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+import { RouterTestingModule } from '@angular/router/testing';
+import { ProfileSidebarComponent } from './profile-sidebar.component';
+import { ProfileResponse } from '../personality/profile/models/profile-response.model';
+
+describe('ProfileSidebarComponent', () => {
+  let component: ProfileSidebarComponent;
+  let fixture: ComponentFixture<ProfileSidebarComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [ProfileSidebarComponent, RouterTestingModule]
+    }).compileComponents();
+
+    fixture = TestBed.createComponent(ProfileSidebarComponent);
+    component = fixture.componentInstance;
+    component.profile = { id: 1 } as ProfileResponse;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/src/app/npc-simulation/profile-sidebar.component.ts
+++ b/src/app/npc-simulation/profile-sidebar.component.ts
@@ -1,0 +1,23 @@
+import { Component, Input } from '@angular/core';
+import { CommonModule } from '@angular/common';
+import { Router } from '@angular/router';
+import { ProfileResponse } from '../personality/profile/models/profile-response.model';
+
+@Component({
+  selector: 'app-profile-sidebar',
+  standalone: true,
+  imports: [CommonModule],
+  templateUrl: './profile-sidebar.component.html',
+  styleUrls: ['./profile-sidebar.component.css']
+})
+export class ProfileSidebarComponent {
+  @Input() profile!: ProfileResponse;
+
+  constructor(private router: Router) {}
+
+  openProfilePage(id: number): void {
+    this.router.navigate(['/profile', id]).then(() => {
+      console.log('Profile button clicked');
+    });
+  }
+}

--- a/src/app/npc-simulation/profile-sidebar.component.ts
+++ b/src/app/npc-simulation/profile-sidebar.component.ts
@@ -8,7 +8,8 @@ import { ProfileResponse } from '../personality/profile/models/profile-response.
   standalone: true,
   imports: [CommonModule],
   templateUrl: './profile-sidebar.component.html',
-  styleUrls: ['./profile-sidebar.component.css']
+  styleUrls: ['./profile-sidebar.component.css'],
+  host: { class: 'profile-sidebar' }
 })
 export class ProfileSidebarComponent {
   @Input() profile!: ProfileResponse;


### PR DESCRIPTION
## Summary
- create new `ProfileSidebarComponent`
- swap sidebar markup to new component
- keep resizing logic intact with a ViewChild for the sidebar element

## Testing
- `npm test` *(fails: ng not found)*

------
https://chatgpt.com/codex/tasks/task_e_684b907b53e4832e95518528aa782e2d