### PR TITLE
Improve profile sidebar layout

### DIFF
--- a/src/app/npc-simulation/npc-simulation.component.spec.ts
+++ b/src/app/npc-simulation/npc-simulation.component.spec.ts
@@ -20,7 +20,7 @@ describe('NpcSimulationComponent', () => {
       getNodes: () => [],
       addNpc: () => {},
       stopSimulation: () => {}
-    } as NpcSimulationService;
+    } as unknown as NpcSimulationService;
 
     await TestBed.configureTestingModule({
       imports: [NpcSimulationComponent, RouterTestingModule],

--- a/src/app/npc-simulation/profile-sidebar.component.css
+++ b/src/app/npc-simulation/profile-sidebar.component.css
@@ -10,10 +10,18 @@
   color: #f0f0f0;
 }
 
-img {
-  width: 100%;
-  border-radius: 4px;
+
+.profile-header {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.5rem;
   margin-bottom: 0.5rem;
+}
+
+.profile-image {
+  width: 80px;
+  height: auto;
+  border-radius: 4px;
 }
 
 .system-votes {

--- a/src/app/npc-simulation/profile-sidebar.component.html
+++ b/src/app/npc-simulation/profile-sidebar.component.html
@@ -1,7 +1,16 @@
-<h3>{{ profile.profile_name || profile.mbti_profile }}</h3>
-  <img *ngIf="profile.profile_image_url" [src]="profile.profile_image_url" alt="{{ profile.profile_name }}" />
-  <p><strong>MBTI:</strong> {{ profile.mbti_type }}</p>
-  <p><strong>Category:</strong> {{ profile.category }} / {{ profile.subcategory }}</p>
+<div class="profile-header">
+  <img
+    *ngIf="profile.profile_image_url"
+    class="profile-image"
+    [src]="profile.profile_image_url"
+    alt="{{ profile.profile_name }}"
+  />
+  <div class="profile-info">
+    <h3>{{ profile.profile_name || profile.mbti_profile }}</h3>
+    <p><strong>MBTI:</strong> {{ profile.mbti_type }}</p>
+    <p><strong>Category:</strong> {{ profile.category }} / {{ profile.subcategory }}</p>
+  </div>
+</div>
   <p><strong>Votes:</strong> {{ profile.vote_count }} | <strong>Comments:</strong> {{ profile.comment_count }}</p>
   <div *ngIf="profile.systems?.length">
     <h4>Best Votes</h4>


### PR DESCRIPTION
## Summary
- rework profile sidebar template to show profile details beside a smaller image
- style sidebar header with flexbox and thumbnail size
- fix NPC simulation spec type assertion for stub service

## Testing
- `npx ng test --browsers=ChromeHeadless --watch=false` *(fails: No binary for ChromeHeadless)*
- `npm install`

------
https://chatgpt.com/codex/tasks/task_e_684dfa736acc832e8fce471c5227723d